### PR TITLE
python 3.10 support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,14 @@
+import sys
+
+# Hack to fix python 3.10 support
+if sys.version_info >= (3, 10):
+    from typing import Mapping
+    import collections
+
+    # imported in prompt_toolkit 1.0.14 which is strictly
+    # relied on by PyInquirer
+    collections.Mapping = Mapping  # type: ignore
+
 # Importing 3rd Party Libraries
 from pyfiglet import Figlet
 from PyInquirer import prompt, Separator


### PR DESCRIPTION
In a quote from Python itself, `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working`

This PR monkey patches support for importing `collections.Mapping` which was finally removed in python 3.10.

This is needed because `PyInquirer` relies on an old version of `prompt_toolkit`. Version 1.0.14 to be exact. If/When `PyInquirer` upgrades `prompt_toolkit` this patch will no longer be needed.

I'd understand if you don't want this hack in your codebase but IMHO it's worth it to have an ugly patch to make the newest Python version work.

LMK what you think :)